### PR TITLE
Ignore the content of GDB server related  scripts so every one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ out
 
 # Toolchain folder
 tools/toolchain/*
+
+# GDB server launching
+tools/cross-system-gdb/wsl/*


### PR DESCRIPTION
Ignore the content of GDB server related  scripts so everyone can customize the parameters and paths to individual needs.